### PR TITLE
Updating NASA public/media streams

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -33,7 +33,7 @@ STATIC_STREAMS = (
     {
         'title': 'Public-Education Channel HD',
         'logo': 'public.jpg',
-        'stream_url': ('https://nasa-i.akamaihd.net/hls/',
+        'stream_url': ('https://nasa-i.akamaihd.net/hls/'
                         'live/253565/NTV-Public/master.m3u8'),
     }, {
         'title': 'ISS Live Stream',
@@ -43,7 +43,7 @@ STATIC_STREAMS = (
     }, {
         'title': 'Media Channel HD',
         'logo': 'media.jpg',
-        'stream_url': ('https://nasa-i.akamaihd.net/hls/', 
+        'stream_url': ('https://nasa-i.akamaihd.net/hls/'
                         'live/253566/NTV-Media/master.m3u8'),
     },{
         'title': 'ISS HD Earth Viewing - ustream',

--- a/addon.py
+++ b/addon.py
@@ -31,25 +31,20 @@ STRINGS = {
 
 STATIC_STREAMS = (
     {
-        'title': 'Nasa TV HD',
+        'title': 'Public-Education Channel HD',
         'logo': 'public.jpg',
-        'stream_url': ('http://nasatv-lh.akamaihd.net/i/'
-                       'NASA_101@319270/master.m3u8'),
+        'stream_url': ('https://nasa-i.akamaihd.net/hls/',
+                        'live/253565/NTV-Public/master.m3u8'),
     }, {
         'title': 'ISS Live Stream',
         'logo': 'iss.jpg',
         'stream_url': ('http://iphone-streaming.ustream.tv/ustreamVideo/'
                        '9408562/streams/live/playlist.m3u8'),
     }, {
-        'title': 'Educational Channel HD',
-        'logo': 'edu.jpg',
-        'stream_url': ('http://nasatv-lh.akamaihd.net/i/'
-                       'NASA_102@319272/master.m3u8'),
-    }, {
         'title': 'Media Channel HD',
         'logo': 'media.jpg',
-        'stream_url': ('http://nasatv-lh.akamaihd.net/i/'
-                       'NASA_103@319271/master.m3u8'),
+        'stream_url': ('https://nasa-i.akamaihd.net/hls/', 
+                        'live/253566/NTV-Media/master.m3u8'),
     },{
         'title': 'ISS HD Earth Viewing - ustream',
         'logo': 'isshd.jpg',


### PR DESCRIPTION
Per the information on this page (https://forum.nasaspaceflight.com/index.php?topic=39438.0 ), I've updated the stream URLs to the new versions, as well as combining the public and educational streams into a single option. The Media channel doesn't work on my OSMC box running on my raspberry pi, but the URL works fine within VLC. Seems like the lower quality streams for the Media channel all resolve to 404s, while the highest quality stream works fine, so possibly things work fine on a Kodi box with more power than my rpi.